### PR TITLE
Add more constraints to QN grammars

### DIFF
--- a/src/qualitative_networks.jl
+++ b/src/qualitative_networks.jl
@@ -80,6 +80,49 @@ function build_qn_grammar(
 
     addconstraint!(g, Forbidden(template_tree))
 
+    # Forbid Ceil and Floor from including an entity or constant directly
+    entities_consts = DomainRuleNode(
+        BitVector([
+            zeros(Int, 9)...,
+            ones(Int, length(entity_names) + length(constants))...,
+        ]),
+    )
+    template_tree = DomainRuleNode(
+        BitVector([
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0,
+            zeros(Int, length(entity_names) + length(constants))...,
+        ]),
+        [entities_consts],
+    )
+
+    addconstraint!(g, Forbidden(template_tree))
+
+    # Forbid ceil(floor(x)) and vice-versa
+    ceil_or_floor = BitVector([
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        0,
+        zeros(Int, length(entity_names) + length(constants))...,
+    ])
+    template_tree =
+        DomainRuleNode(ceil_or_floor, [DomainRuleNode(ceil_or_floor, [VarNode(:a)])])
+
+    addconstraint!(g, Forbidden(template_tree))
+
     return g
 end
 


### PR DESCRIPTION
This PR adds two constraints on QN grammars

- Constrain Ceil and Floor in QN grammar to not directly include a entity or constant
- Forbid ceil(floor)

## Related issues

There is no related issue.


## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/ReubenJ/GraphDynamicalSystems.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
