### PR TITLE
fix: deepcopy grammar constraint domains

### DIFF
--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -1,0 +1,2 @@
+[GraphDynamicalSystems]
+dispatch_doctor_mode = "debug"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GraphDynamicalSystems"
 uuid = "13529e2e-ed53-56b1-bd6f-420b01fca819"
 authors = ["Reuben Gardos Reid <5456207+ReubenJ@users.noreply.github.com>"]
-version = "0.0.1"
+version = "0.0.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/test/qn_test.jl
+++ b/test/qn_test.jl
@@ -15,16 +15,11 @@ end
 
 @testitem "QN Grammar Creation" begin
     entities = [:a, :b, :c]
-    constants = [i for i = 1:10]
+    constants = [i for i = 0:10]
     g = build_qn_grammar(entities, constants)
 
     @test issubset(Set(entities), Set(g.rules))
     @test issubset(Set(constants), Set(g.rules))
-
-    g2 = build_qn_grammar(Symbol[], Integer[])
-
-    @test isempty(intersect(Set(g2.rules), Set(entities)))
-    @test isempty(intersect(Set(g2.rules), Set(constants)))
 end
 
 @testitem "QN Sampling" setup = [RandomSetup, ExampleQN] begin


### PR DESCRIPTION
There is no related issue.

This fix is necessary to prevent subsequent constraints from modifying the previous constraints' domains.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/ReubenJ/GraphDynamicalSystems.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
