### PR TITLE
feat: add `default_target_function`

### DIFF
--- a/src/GraphDynamicalSystems.jl
+++ b/src/GraphDynamicalSystems.jl
@@ -23,6 +23,7 @@ export QualitativeNetwork,
     get_domain,
     target_functions,
     interpret,
-    create_qn_system
+    create_qn_system,
+    default_target_function
 
 end

--- a/test/qn_test.jl
+++ b/test/qn_test.jl
@@ -112,3 +112,32 @@ end
 
     basins = basins_of_attraction(mapper, grid)
 end
+
+@testitem "Construct default target functions" begin
+    lower_bound = 0
+    upper_bound = 4
+    activators = [:A, :B, :C]
+    inhibitors = [:D, :E, :F]
+
+    @test default_target_function(lower_bound, upper_bound, activators, inhibitors) ==
+          :(max($lower_bound, (A + B + C) / 3 - (D + E + F) / 3))
+
+    activators = [:A, :B]
+    inhibitors = [:D]
+
+    @test default_target_function(lower_bound, upper_bound, activators, inhibitors) ==
+          :(max($lower_bound, (A + B) / 2 - D))
+
+    activators = []
+    inhibitors = [:D]
+
+    @test default_target_function(lower_bound, upper_bound, activators, inhibitors) ==
+          :($upper_bound - D)
+
+    activators = [:A]
+    inhibitors = []
+
+    @test default_target_function(lower_bound, upper_bound, activators, inhibitors) == :(A)
+
+    @test_throws r"no activators or inhibitors" default_target_function(0, 4)
+end


### PR DESCRIPTION
Add a function that creates a default target function for an entity of a QN as described in Eq. 3 from the [QN paper](https://doi.org/10.1186/1752-0509-1-4).

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/ReubenJ/GraphDynamicalSystems.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
