### PR TITLE
Swap direction of edges in `update_functions_to_interaction_graph`

### DIFF
--- a/src/qualitative_networks.jl
+++ b/src/qualitative_networks.jl
@@ -239,10 +239,10 @@ function update_functions_to_interaction_graph(
         graph[entity] = Entity{Int}(fn, domain)
     end
 
-    for (e1, f) in zip(entities, update_functions)
+    for (dst, f) in zip(entities, update_functions)
         input_entities = collect(Leaves(f))
-        for e2 in input_entities
-            add_edge!(graph, e1, e2)
+        for src in input_entities
+            add_edge!(graph, src, dst)
         end
     end
 

--- a/test/qn_test.jl
+++ b/test/qn_test.jl
@@ -22,6 +22,19 @@ end
     @test issubset(Set(constants), Set(g.rules))
 end
 
+@testitem "QN Graph Correctness" begin
+    entities = [:a, :b, :c]
+    target_fns = Union{Expr,Integer,Symbol}[:(-c), :a, :b]
+    domains = [0:2 for _ = 1:3]
+
+    qn = QN(entities, target_fns, domains)
+    g = get_graph(qn)
+
+    @test haskey(g, :c, :a)
+    @test haskey(g, :a, :b)
+    @test haskey(g, :b, :c)
+end
+
 @testitem "QN Sampling" setup = [RandomSetup, ExampleQN] begin
     using Graphs: ne, nv
     graph = get_graph(qn)


### PR DESCRIPTION
Currently, the edges of the graph structure stored in the dynamical system were swapped. This PR tests for the correct direction and fix the problem.

There is no related issue.


## Checklist

- [x] I am following the [contributing guidelines](https://github.com/ReubenJ/GraphDynamicalSystems.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
