### PR TITLE
Remove override for `nixpkgs` for `utils` input in dev. env. flake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,5 @@ repos:
       rev: v2.0.1
       hooks:
           - id: runic
+            additional_dependencies:
+                - "Runic"

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils = {
       url = "github:numtide/flake-utils";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
   outputs = {


### PR DESCRIPTION
The `utils` input does not use `nixpkgs`, meaning the override did nothing

- [x] I am following the [contributing guidelines](https://github.com/ReubenJ/GraphDynamicalSystems.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
