### PR TITLE
ci: don't specify aarch for `setup-julia`

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -28,6 +28,4 @@ jobs:
                     - ubuntu-latest
                     - macOS-latest
                     - windows-latest
-                arch:
-                    - x64
                 allow_failure: [false]


### PR DESCRIPTION
Read the release notes for breaking releases... no really, read them 🤓 