### PR TITLE
tooling: don't specify Runic version for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,5 +48,3 @@ repos:
       rev: v2.1.0
       hooks:
           - id: runic
-            additional_dependencies:
-                - "Runic"


### PR DESCRIPTION
Actions failing due to missing `Runic` dep. Possibly addresses?