### PR TITLE
tooling: don't run no-commit-to-branch on CI

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -21,6 +21,8 @@ jobs:
             - name: Clone
               uses: actions/checkout@v6
             - uses: j178/prek-action@v2
+              with:
+                  extra-args: "--all-files --skip no-commit-to-branch"
 
     link-checker:
         name: Link checker


### PR DESCRIPTION
`no-commit-to-branch` fails in CI, but it's meant to catch local commits to `main`, not commits due to PRs. Skipping in CI.