### PR TITLE
ci: build `test` project

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -42,6 +42,8 @@ jobs:
             - name: Use Julia cache
               uses: julia-actions/cache@v3
             - uses: julia-actions/julia-buildpkg@v1
+              with:
+                  project: "test"
             - uses: julia-actions/julia-runtest@v1
             - uses: julia-actions/julia-processcoverage@v1
               if: ${{ inputs.run_codecov }}


### PR DESCRIPTION
It seems like the caching is only caching the main project because the action to build the package was pointing to the main `Project.toml`. This means that every CI is super long. Hopefully this addresses the issue by caching the entire project with test dependencies.